### PR TITLE
enable parsing label without literal wrapper

### DIFF
--- a/data/slds/point_simpleLabel.sld
+++ b/data/slds/point_simpleLabel.sld
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Styled Label</Name>
+    <UserStyle>
+      <Title>Styled Label</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <TextSymbolizer>
+            <Label>myText</Label>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_simpleLabel.ts
+++ b/data/styles/point_simpleLabel.ts
@@ -1,0 +1,14 @@
+import { Style } from 'geostyler-style';
+
+const pointStyledLabel: Style = {
+  name: 'Styled Label',
+  rules: [{
+    name: '',
+    symbolizers: [{
+      kind: 'Text',
+      label: 'myText'
+    }]
+  }]
+};
+
+export default pointStyledLabel;

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -13,6 +13,7 @@ import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygo
 import polygon_graphicFill from '../data/styles/polygon_graphicFill';
 import polygon_graphicFill_externalGraphic from '../data/styles/polygon_graphicFill_externalGraphic';
 import point_styledlabel from '../data/styles/point_styledlabel';
+import point_simpleLabel from '../data/styles/point_simpleLabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 import point_simplepoint_filter_forceBools from '../data/styles/point_simplepoint_filter_forceBools';
 import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplepoint_filter_forceNumerics';
@@ -238,6 +239,15 @@ describe('SldStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_styledlabel);
+        });
+    });
+    it('can read a SLD TextSymbolizer with a static label', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_simpleLabel.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simpleLabel);
         });
     });
     it('can read a simple SLD RasterSymbolizer', () => {

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -943,6 +943,8 @@ export class SldStyleParser implements StyleParser {
       // if no placeholders are being used
       // create a simple string
       label = literals.join('');
+    } else if (typeof sldLabel === 'string') {
+      label = sldLabel;
     }
     return label;
   }


### PR DESCRIPTION
Enables reading a sld label in the format of `<Label>myLabel</Label>` additionally to supported formats, such as `<Label><Literal>myLabel</Literal></Label>`.

However, we will face problems writing such labels, as from the current `geostyler-style` definition, we cannot distinguish in which of the above mentioned formats we should write to. Even though, it probably will not make a difference visually, this will lead to not being able to create the exactly same sld after reading and writing.

 @KaiVolland do you have any suggestions, how we could solve that problem?

solves #266 

**Note:** With this PR we will only change reading a SLD and the writing will remain untouched due to above mentioned problem. Since there is no semantic difference in the output, all writes to SLD that contain a static label will be wrapped into a `<Literal>` tag.