### PR TITLE
Update deprecated urls in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/terrestris/geostyler-sld-parser.git"
+    "url": "git+https://github.com/geostyler/geostyler-sld-parser.git"
   },
   "keywords": [
     "geostyler",
@@ -21,9 +21,9 @@
   "author": "",
   "license": "BSD-2-Clause",
   "bugs": {
-    "url": "https://github.com/terrestris/geostyler-sld-parser/issues"
+    "url": "https://github.com/geostyler/geostyler-sld-parser/issues"
   },
-  "homepage": "https://github.com/terrestris/geostyler-sld-parser#readme",
+  "homepage": "https://github.com/geostyler/geostyler-sld-parser#readme",
   "dependencies": {
     "geostyler-style": "^2.0.3",
     "lodash": "^4.17.15",
@@ -40,7 +40,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
-    "release": "np --no-yarn && git push https://github.com/terrestris/geostyler-sld-parser.git master --tags"
+    "release": "np --no-yarn && git push https://github.com/geostyler/geostyler-sld-parser.git master --tags"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",


### PR DESCRIPTION
The urls in package.json still referenced the old repository on the terrestris organisation. This will be fixed in this PR.

Note: Referencing also works with the old urls, since github forwards them. However, this was done to have a cleaner project.