### PR TITLE
Handle ttf:// format for symbols in mark symbolizers

### DIFF
--- a/data/slds/point_fontglyph.sld
+++ b/data/slds/point_fontglyph.sld
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Font Glyph</Name>
+    <UserStyle>
+      <Title>Font Glyph</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Small populated New Yorks</Name>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>ttf://My Font Name#0x0A23</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill-opacity">0.5</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">#0000FF</CssParameter>
+                  <CssParameter name="stroke-opacity">0.7</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>10</Size>
+              <Opacity>1</Opacity>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_fontglyph.ts
+++ b/data/styles/point_fontglyph.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const pointSimpleCross: Style = {
+  'name': 'Font Glyph',
+  'rules': [{
+    'name': 'Small populated New Yorks',
+    'symbolizers': [{
+      'kind': 'Mark',
+      'wellKnownName': 'ttf://My Font Name#0x0A23',
+      'color': '#FF0000',
+      'radius': 5,
+      'opacity': 1,
+      'fillOpacity': 0.5,
+      'strokeColor': '#0000FF',
+      'strokeOpacity': 0.7
+    }]
+  }]
+};
+
+export default pointSimpleCross;

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -31,6 +31,7 @@ import point_simplestar from '../data/styles/point_simplestar';
 import point_simplecross from '../data/styles/point_simplecross';
 import point_simplex from '../data/styles/point_simplex';
 import point_simpleslash from '../data/styles/point_simpleslash';
+import point_fontglyph from '../data/styles/point_fontglyph';
 import point_styledLabel_literalPlaceholder from '../data/styles/point_styledLabel_literalPlaceholder';
 import raster_simpleraster from '../data/styles/raster_simpleRaster';
 import raster_complexraster from '../data/styles/raster_complexRaster';
@@ -151,6 +152,15 @@ describe('SldStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simpleslash);
+        });
+    });
+    it('can read a SLD PointSymbolizer with wellKnownName using a font glyph (starting with ttf://)', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_fontglyph.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_fontglyph);
         });
     });
     it('can read a SLD LineSymbolizer', () => {
@@ -507,6 +517,19 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(point_simpleslash);
+            });
+        });
+    });
+    it('can write a SLD PointSymbolizer with wellKnownName using a font glyph (starting with ttf://)', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(point_fontglyph)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between two XML-Strings is awkward and nonsens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_fontglyph);
             });
         });
     });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -44,6 +44,8 @@ export type ConstructorParams = {
   prettyOutput?: boolean;
 };
 
+const WELLKNOWNNAME_TTF_REGEXP = /^ttf:\/\/(.+)#(.+)$/;
+
 /**
  * This parser can be used with the GeoStyler.
  * It implements the GeoStyler-Style StyleParser interface.
@@ -440,6 +442,10 @@ export class SldStyleParser implements StyleParser {
         markSymbolizer.wellKnownName = wellKnownName as WellKnownName;
         break;
       default:
+        if (WELLKNOWNNAME_TTF_REGEXP.test(wellKnownName)) {
+          markSymbolizer.wellKnownName = wellKnownName as WellKnownName;
+          break;
+        }
         throw new Error('MarkSymbolizer cannot be parsed. Unsupported WellKnownName.');
     }
 
@@ -1699,9 +1705,10 @@ export class SldStyleParser implements StyleParser {
    * Mark (readable with xml2js)
    */
   getSldPointSymbolizerFromMarkSymbolizer(markSymbolizer: MarkSymbolizer): any {
+    const isFontSymbol = WELLKNOWNNAME_TTF_REGEXP.test(markSymbolizer.wellKnownName);
     const mark: any[] = [{
       'WellKnownName': [
-        markSymbolizer.wellKnownName.toLowerCase()
+        isFontSymbol ? markSymbolizer.wellKnownName : markSymbolizer.wellKnownName.toLowerCase()
       ]
     }];
 


### PR DESCRIPTION
This simply required not transforming to lowercase when writing SLD since the font name can contain uppercase characters, and these should be kept in order for GeoTools to be able to recognize the symbol.

The regexp to detect of a symbol is a font glyph was inspired by the one used in Geotools:
https://github.com/geotools/geotools/blob/b695b08d10499d3d670cfc94cda77de42134d1a0/modules/library/render/src/main/java/org/geotools/renderer/style/TTFMarkFactory.java#L68-L73