### PR TITLE
Drop xmldom from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12782,11 +12782,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "stream": "0.0.2",
     "string_decoder": "^1.3.0",
     "timers": "^0.1.1",
-    "xml2js": "^0.4.23",
-    "xmldom": "^0.6.0"
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",


### PR DESCRIPTION
#5 removed the code that used `xmldom` and `@types/xmldom` devDependency but missed the `xmldom` dependency. I used node 12 to run `npm install`.

Since then, several PRs from automated tools kept the unused dependency up-to-date.
`xmldom@0.6.0` is vulnerable and can no longer be updated by the maintainers:
https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q
https://github.com/xmldom/xmldom/issues/271

So it's easier to finally drop the dependency than doing another upgrade.