### PR TITLE
Fix text fillcolor parsing

### DIFF
--- a/data/slds/1.0/point_simpleLabel2.sld
+++ b/data/slds/1.0/point_simpleLabel2.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Styled Label</Name>
+    <UserStyle>
+      <Title>Styled Label</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Rule 1</Name>
+          <TextSymbolizer>
+            <Label>
+              <ogc:Literal>Your Label</ogc:Literal>
+            </Label>
+            <Font>
+              <CssParameter name="font-size">12</CssParameter>
+            </Font>
+            <Fill>
+              <CssParameter name="fill">#2476ad</CssParameter>
+              <CssParameter name="fill-opacity">1</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/slds/1.1/point_simpleLabel2.sld
+++ b/data/slds/1.1/point_simpleLabel2.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>Styled Label</se:Name>
+    <UserStyle>
+      <se:Name>Styled Label</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Rule 1</se:Name>
+          <se:TextSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">
+            <se:Label>
+              <ogc:Literal>Your Label</ogc:Literal>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-size">12</se:SvgParameter>
+            </se:Font>
+            <se:Fill>
+              <se:SvgParameter name="fill">#2476ad</se:SvgParameter>
+              <se:SvgParameter name="fill-opacity">1</se:SvgParameter>
+            </se:Fill>
+          </se:TextSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_simpleLabel2.ts
+++ b/data/styles/point_simpleLabel2.ts
@@ -1,0 +1,21 @@
+import { Style } from 'geostyler-style';
+
+const pointStyledLabel: Style = {
+  'name': 'Styled Label',
+  'rules': [
+    {
+      'name': 'Rule 1',
+      'symbolizers': [
+        {
+          'kind': 'Text',
+          'label': 'Your Label',
+          'color': '#2476ad',
+          'opacity': 1,
+          'size': 12
+        }
+      ]
+    }
+  ]
+};
+
+export default pointStyledLabel;

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1064,9 +1064,9 @@ export class SldStyleParser implements StyleParser<string> {
 
     let fillCssParameters;
     if (this.sldVersion === '1.0.0') {
-      fillCssParameters = _get(sldSymbolizer, 'Fill[0].CssParameters') || [];
+      fillCssParameters = _get(sldSymbolizer, 'Fill[0].CssParameter') || [];
     } else {
-      fillCssParameters = _get(sldSymbolizer, 'Fill[0].SvgParameters') || [];
+      fillCssParameters = _get(sldSymbolizer, 'Fill[0].SvgParameter') || [];
     }
     let color = '#000000';
     let opacity = 1;

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -15,6 +15,7 @@ import polygon_graphicFill from '../data/styles/polygon_graphicFill';
 import polygon_graphicFill_externalGraphic from '../data/styles/polygon_graphicFill_externalGraphic';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simpleLabel from '../data/styles/point_simpleLabel';
+import point_simpleLabel2 from '../data/styles/point_simpleLabel2';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 import point_simplepoint_filter_forceBools from '../data/styles/point_simplepoint_filter_forceBools';
 import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplepoint_filter_forceNumerics';
@@ -195,6 +196,12 @@ describe('SldStyleParser implements StyleParser', () => {
       const { output: geoStylerStyle} = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpleLabel);
+    });
+    it('can read a SLD TextSymbolizer with a static label and styling', async () => {
+      const sld = fs.readFileSync('./data/slds/1.0/point_simpleLabel2.sld', 'utf8');
+      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simpleLabel2);
     });
     it('can read a simple SLD RasterSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.0/raster_simpleRaster.sld', 'utf8');

--- a/src/SldStyleParser.v1.1.spec.ts
+++ b/src/SldStyleParser.v1.1.spec.ts
@@ -15,6 +15,7 @@ import polygon_graphicFill from '../data/styles/polygon_graphicFill';
 import polygon_graphicFill_externalGraphic from '../data/styles/polygon_graphicFill_externalGraphic';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simpleLabel from '../data/styles/point_simpleLabel';
+import point_simpleLabel2 from '../data/styles/point_simpleLabel2';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 import point_simplepoint_filter_forceBools from '../data/styles/point_simplepoint_filter_forceBools';
 import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplepoint_filter_forceNumerics';
@@ -184,6 +185,12 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser', () => 
       const { output: geoStylerStyle} = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpleLabel);
+    });
+    it('can read a SLD 1.1 TextSymbolizer with a static label and styling', async () => {
+      const sld = fs.readFileSync('./data/slds/1.1/point_simpleLabel2.sld', 'utf8');
+      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simpleLabel2);
     });
     it('can read a simple SLD 1.1 RasterSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/raster_simpleRaster.sld', 'utf8');


### PR DESCRIPTION
This fixes #524

The bug was caused by a falsly used plural on `CssParameter` and `SvgParameter`.
Some tests where added.