### PR TITLE
Adds unsupportedProperties feedback to WriteStyleResult

### DIFF
--- a/data/slds/1.0/unsupported_properties.sld
+++ b/data/slds/1.0/unsupported_properties.sld
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>OL Style</Name>
+    <UserStyle>
+      <Name>OL Style</Name>
+      <Title>OL Style</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>OL Style Rule 0</Name>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#F1337F</CssParameter>
+            </Fill>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/slds/1.1/unsupported_properties.sld
+++ b/data/slds/1.1/unsupported_properties.sld
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>OL Style</se:Name>
+    <UserStyle>
+      <se:Name>OL Style</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>OL Style Rule 0</se:Name>
+          <se:PolygonSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">
+            <se:Fill>
+              <se:SvgParameter name="fill">#F1337F</se:SvgParameter>
+            </se:Fill>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/unsupported_properties.ts
+++ b/data/styles/unsupported_properties.ts
@@ -1,0 +1,17 @@
+import { Style } from 'geostyler-style';
+
+const unsupportedProperties: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Fill',
+        color: '#F1337F',
+        opacity: 0.5
+      }]
+    }
+  ]
+};
+
+export default unsupportedProperties;

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -37,6 +37,7 @@ import point_styledLabel_literalPlaceholder from '../data/styles/point_styledLab
 import point_styledLabel_elementOrder from '../data/styles/point_styledLabel_elementOrder';
 import raster_simpleraster from '../data/styles/raster_simpleRaster';
 import raster_complexraster from '../data/styles/raster_complexRaster';
+import unsupported_properties from '../data/styles/unsupported_properties';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -606,6 +607,30 @@ describe('SldStyleParser implements StyleParser', () => {
       const { output: sldString} = await styleParserOrder.writeStyle(point_styledLabel_elementOrder);
       expect(sldString).toBeDefined();
       const sld = fs.readFileSync('./data/slds/1.0/point_styledLabel_elementOrder.sld', 'utf8');
+      expect(sldString).toEqual(sld.trim());
+    });
+    it('adds unsupportedProperties to the write output', async () => {
+      const styleParserOrder = new SldStyleParser();
+      const {
+        output: sldString,
+        unsupportedProperties,
+        warnings
+      } = await styleParserOrder.writeStyle(unsupported_properties);
+      expect(sldString).toBeDefined();
+      const unsupportedGot = {
+        Symbolizer: {
+          FillSymbolizer: {
+            opacity: {
+              info: 'General opacity is not supported. Use fillOpacity and strokeOpacity instead.',
+              support: 'none'
+            }
+          }
+        }
+      };
+      const warningsGot = ['Your style contains unsupportedProperties!'];
+      expect(unsupportedProperties).toEqual(unsupportedGot);
+      expect(warnings).toEqual(warningsGot);
+      const sld = fs.readFileSync('./data/slds/1.0/unsupported_properties.sld', 'utf8');
       expect(sldString).toEqual(sld.trim());
     });
 

--- a/src/SldStyleParser.v1.1.spec.ts
+++ b/src/SldStyleParser.v1.1.spec.ts
@@ -37,6 +37,7 @@ import point_styledLabel_literalPlaceholder from '../data/styles/point_styledLab
 import point_styledLabel_elementOrder from '../data/styles/point_styledLabel_elementOrder';
 import raster_simpleraster from '../data/styles/raster_simpleRaster';
 import raster_complexraster from '../data/styles/raster_complexRaster';
+import unsupported_properties from '../data/styles/unsupported_properties';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -598,6 +599,30 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser', () => 
       const { output: sldString } = await styleParserOrder.writeStyle(point_styledLabel_elementOrder);
       expect(sldString).toBeDefined();
       const sld = fs.readFileSync('./data/slds/1.1/point_styledLabel_elementOrder.sld', 'utf8');
+      expect(sldString).toEqual(sld.trim());
+    });
+    it('adds unsupportedProperties to the write output', async () => {
+      const styleParserOrder = new SldStyleParser({ sldVersion: '1.1.0' });
+      const {
+        output: sldString,
+        unsupportedProperties,
+        warnings
+      } = await styleParserOrder.writeStyle(unsupported_properties);
+      expect(sldString).toBeDefined();
+      const unsupportedGot = {
+        Symbolizer: {
+          FillSymbolizer: {
+            opacity: {
+              info: 'General opacity is not supported. Use fillOpacity and strokeOpacity instead.',
+              support: 'none'
+            }
+          }
+        }
+      };
+      const warningsGot = ['Your style contains unsupportedProperties!'];
+      expect(unsupportedProperties).toEqual(unsupportedGot);
+      expect(warnings).toEqual(warningsGot);
+      const sld = fs.readFileSync('./data/slds/1.1/unsupported_properties.sld', 'utf8');
       expect(sldString).toEqual(sld.trim());
     });
 


### PR DESCRIPTION
## Description

This adds the `unsupportedProperties` to the `WriteStyleResult`.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
