### PR TITLE
Fix `checkForUnsupportedProperties`

### DIFF
--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1329,19 +1329,19 @@ export class SldStyleParser implements StyleParser<string> {
         const key = capitalizeFirstLetter(`${symbolizer.kind}Symbolizer`);
         const value = this.unsupportedProperties?.Symbolizer?.[key];
         if (value) {
-          if (!unsupportedProperties.Symbolizer) {
-            unsupportedProperties.Symbolizer = {};
-          }
           if (typeof value === 'string' || value instanceof String ) {
+            if (!unsupportedProperties.Symbolizer) {
+              unsupportedProperties.Symbolizer = {};
+            }
             unsupportedProperties.Symbolizer[key] = value;
           } else {
-            if (!unsupportedProperties.Symbolizer[key]) {
-              unsupportedProperties.Symbolizer[key] = {};
-            }
             Object.keys(symbolizer).forEach(property => {
               if (value[property]) {
                 if (!unsupportedProperties.Symbolizer) {
                   unsupportedProperties.Symbolizer = {};
+                }
+                if (!unsupportedProperties.Symbolizer[key]) {
+                  unsupportedProperties.Symbolizer[key] = {};
                 }
                 unsupportedProperties.Symbolizer[key][property] = value[property];
               }

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -340,8 +340,16 @@ describe('SldStyleParser implements StyleParser', () => {
     });
 
     it('can write a SLD PointSymbolizer', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
@@ -349,176 +357,352 @@ describe('SldStyleParser implements StyleParser', () => {
     });
 
     it('can write a SLD PointSymbolizer with ExternalGraphic', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_externalgraphic);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_externalgraphic);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_externalgraphic);
     });
     it('can write a SLD PointSymbolizer with ExternalGraphic svg', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_externalgraphic_svg);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_externalgraphic_svg);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_externalgraphic_svg);
     });
     it('can write a SLD PointSymbolizer with wellKnownName square', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplesquare);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplesquare);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplesquare);
     });
     it('can write a SLD PointSymbolizer with wellKnownName triangle', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simpletriangle);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simpletriangle);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simpletriangle);
     });
     it('can write a SLD PointSymbolizer with wellKnownName star', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplestar);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplestar);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplestar);
     });
     it('can write a SLD PointSymbolizer with wellKnownName cross', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplecross);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplecross);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplecross);
     });
     it('can write a SLD PointSymbolizer with wellKnownName x', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplex);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplex);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplex);
     });
     it('can write a SLD PointSymbolizer with wellKnownName shape://slash', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simpleslash);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simpleslash);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simpleslash);
     });
     it('can write a SLD PointSymbolizer with wellKnownName using a font glyph (starting with ttf://)', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_fontglyph);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_fontglyph);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_fontglyph);
     });
     it('can write a SLD LineSymbolizer', async () => {
-      const { output: sldString} = await styleParser.writeStyle(line_simpleline);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(line_simpleline);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(line_simpleline);
     });
     it('can write a SLD LineSymbolizer with PerpendicularOffset', async () => {
-      const { output: sldString} = await styleParser.writeStyle(line_perpendicularOffset);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(line_perpendicularOffset);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(line_perpendicularOffset);
     });
     it('can write a SLD LineSymbolizer with GraphicStroke', async () => {
-      const { output: sldString} = await styleParser.writeStyle(line_graphicStroke);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(line_graphicStroke);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(line_graphicStroke);
     });
     it('can write a SLD LineSymbolizer with GraphicStroke and ExternalGraphic', async () => {
-      const { output: sldString} = await styleParser.writeStyle(line_graphicStroke_externalGraphic);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(line_graphicStroke_externalGraphic);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(line_graphicStroke_externalGraphic);
     });
     it('can write a SLD LineSymbolizer with GraphicFill', async () => {
-      const { output: sldString} = await styleParser.writeStyle(line_graphicFill);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(line_graphicFill);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(line_graphicFill);
     });
     it('can write a SLD LineSymbolizer with GraphicFill and ExternalGraphic', async () => {
-      const { output: sldString} = await styleParser.writeStyle(line_graphicFill_externalGraphic);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(line_graphicFill_externalGraphic);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(line_graphicFill_externalGraphic);
     });
     it('can write a SLD PolygonSymbolizer', async () => {
-      const { output: sldString} = await styleParser.writeStyle(polygon_transparentpolygon);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(polygon_transparentpolygon);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(polygon_transparentpolygon);
     });
     it('can write a SLD PolygonSymbolizer with GraphicFill', async () => {
-      const { output: sldString} = await styleParser.writeStyle(polygon_graphicFill);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(polygon_graphicFill);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(polygon_graphicFill);
     });
     it('can write a SLD PolygonSymbolizer with GraphicFill and ExternalGraphic', async () => {
-      const { output: sldString} = await styleParser.writeStyle(polygon_graphicFill_externalGraphic);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(polygon_graphicFill_externalGraphic);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(polygon_graphicFill_externalGraphic);
     });
     it('can write a SLD TextSymbolizer', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_styledlabel);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_styledlabel);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_styledlabel);
     });
     it('can write a simple SLD RasterSymbolizer', async () => {
-      const { output: sldString} = await styleParser.writeStyle(raster_simpleraster);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(raster_simpleraster);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(raster_simpleraster);
     });
     it('can write a complex SLD RasterSymbolizer', async () => {
-      const { output: sldString} = await styleParser.writeStyle(raster_complexraster);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(raster_complexraster);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(raster_complexraster);
     });
     it('can write a SLD style with a filter', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_filter);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_filter);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
@@ -527,8 +711,16 @@ describe('SldStyleParser implements StyleParser', () => {
     it('can write a SLD style with a filter and force cast of numeric fields', async () => {
       // force fields beeing casted to numeric data type
       styleParser.numericFilterFields = ['POPULATION', 'TEST1', 'TEST2'];
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_filter_forceNumerics);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_filter_forceNumerics);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
@@ -536,8 +728,16 @@ describe('SldStyleParser implements StyleParser', () => {
     });
     it('can write a SLD style with a filter and force cast of numeric fields (forceCasting)', async () => {
       styleParser.forceCasting = true;
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_filter_forceNumerics);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_filter_forceNumerics);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
@@ -546,8 +746,16 @@ describe('SldStyleParser implements StyleParser', () => {
     it('can write a SLD style with a filter and force cast of boolean fields', async () => {
       // force fields beeing casted to boolean data type
       styleParser.boolFilterFields = ['TEST', 'TEST2'];
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_filter_forceBools);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_filter_forceBools);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
@@ -556,40 +764,80 @@ describe('SldStyleParser implements StyleParser', () => {
     it('can write a SLD style with a filter and force cast of boolean fields (forceCasting)', async () => {
       // force fields beeing casted to boolean data type
       styleParser.forceCasting = true;
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_filter_forceBools);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_filter_forceBools);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD style with nested logical filters', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_nestedLogicalFilters);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_nestedLogicalFilters);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplepoint_nestedLogicalFilters);
     });
     it('can write a SLD style with functionfilters', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_simplepoint_functionfilter);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_simplepoint_functionfilter);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(point_simplepoint_functionfilter);
     });
     it('can write a SLD style with multiple symbolizers in one Rule', async () => {
-      const { output: sldString} = await styleParser.writeStyle(multi_simplelineLabel);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(multi_simplelineLabel);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);
       expect(readStyle).toEqual(multi_simplelineLabel);
     });
     it('can write a SLD style with a styled label containing a placeholder and static text', async () => {
-      const { output: sldString} = await styleParser.writeStyle(point_styledLabel_literalPlaceholder);
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(point_styledLabel_literalPlaceholder);
       expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString);


### PR DESCRIPTION
This fixes `checkForUnsupportedProperties` and extends the tests correspondingly.