### PR TITLE
fix: enable parsing of raster SLD without opacity

### DIFF
--- a/data/slds/1.0/raster_without_opacity.sld
+++ b/data/slds/1.0/raster_without_opacity.sld
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0">
+    <sld:NamedLayer>
+        <sld:Name>Default Styler</sld:Name>
+        <sld:UserStyle>
+            <sld:Name>Default Styler</sld:Name>
+            <sld:Title>Default Styler</sld:Title>
+            <sld:FeatureTypeStyle>
+                <sld:Name>name</sld:Name>
+                <sld:Rule>
+                    <sld:RasterSymbolizer>
+                        <sld:ColorMap type="intervals">
+                            <sld:ColorMapEntry color="#ffffff" opacity="1.0" quantity="1.0001"/>
+                            <sld:ColorMapEntry color="#ff0000" opacity="1.0" quantity="50000.0001"/>
+                            <sld:ColorMapEntry color="#ffff00" opacity="1.0" quantity="100000.0001"/>
+                            <sld:ColorMapEntry color="#00aa00" opacity="1.0" quantity="10000000" label="100000 &lt; x"/>
+                        </sld:ColorMap>
+                        <sld:ContrastEnhancement/>
+                    </sld:RasterSymbolizer>
+                </sld:Rule>
+            </sld:FeatureTypeStyle>
+        </sld:UserStyle>
+    </sld:NamedLayer>
+</sld:StyledLayerDescriptor>

--- a/data/styles/raster_without_opacity.ts
+++ b/data/styles/raster_without_opacity.ts
@@ -1,0 +1,44 @@
+import { Style } from 'geostyler-style';
+
+const rasterWithoutOpacity: Style = {
+  name:'Default Styler',
+  rules:[
+    {
+      name:'',
+      symbolizers:[
+        {
+          kind:'Raster',
+          colorMap:{
+            type:'intervals',
+            colorMapEntries:[
+              {
+                color:'#ffffff',
+                quantity:1.0001,
+                opacity:1
+              },
+              {
+                color:'#ff0000',
+                quantity:50000.0001,
+                opacity:1
+              },
+              {
+                color:'#ffff00',
+                quantity:100000.0001,
+                opacity:1
+              },
+              {
+                color:'#00aa00',
+                quantity:10000000,
+                label:'100000 < x',
+                opacity:1
+              }
+            ]
+          },
+          contrastEnhancement:{}
+        }
+      ]
+    }
+  ]
+};
+
+export default rasterWithoutOpacity;

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -2230,8 +2230,9 @@ export class SldStyleParser implements StyleParser<string> {
    * @return The object representation of a SLD RasterSymbolizer (readable with fast-xml-parser)
    */
   getSldRasterSymbolizerFromRasterSymbolizer(rasterSymbolizer: GsRasterSymbolizer): any {
-    const sldRasterSymbolizer: any = [{}];
+    const sldRasterSymbolizer: any = [];
     if (rasterSymbolizer.opacity !== undefined) {
+      sldRasterSymbolizer.push({});
       sldRasterSymbolizer[0].Opacity = [{
         '#text': rasterSymbolizer.opacity
       }];

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -38,6 +38,7 @@ import point_styledLabel_literalPlaceholder from '../data/styles/point_styledLab
 import point_styledLabel_elementOrder from '../data/styles/point_styledLabel_elementOrder';
 import raster_simpleraster from '../data/styles/raster_simpleRaster';
 import raster_complexraster from '../data/styles/raster_complexRaster';
+import raster_without_opacity from '../data/styles/raster_without_opacity';
 import unsupported_properties from '../data/styles/unsupported_properties';
 import function_markSymbolizer from '../data/styles/function_markSymbolizer';
 import function_filter from '../data/styles/function_filter';
@@ -207,6 +208,12 @@ describe('SldStyleParser implements StyleParser', () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(raster_complexraster);
+    });
+    it('can read a SLD RasterSymbolizer without opacity', async () => {
+      const sld = fs.readFileSync('./data/slds/1.0/raster_without_opacity.sld', 'utf8');
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(raster_without_opacity);
     });
     it('can read a SLD style with a filter', async () => {
       const sld = fs.readFileSync('./data/slds/1.0/point_simplepoint_filter.sld', 'utf8');


### PR DESCRIPTION
## Description

Writing a parsed raster SLD without opacity (as added in this PR for the test) failed as the `sldRasterSymbolizer` (see diff) array contained an empty object in that scenario that lead to an error in the later processing.

This change fixes the problem.

Thx @dnlkoch for the help in debugging this.


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [x] I'm lost; why do I have to check so many boxes? Please help!
