### PR TITLE
Add support for graphic displacement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,33 +2,15 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Jest Tests",
       "type": "node",
       "request": "launch",
-      "port": 9230,
-      "runtimeArgs": [
-        "--inspect-brk=9230",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--runInBand",
-        "--watch"
-      ],
-      "runtimeExecutable": null,
+      "name": "Debug Current Test File",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "${relativeFile}"],
+      "smartStep": true,
       "console": "integratedTerminal"
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Debug Jest Tests Windows",
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest",
-      "args": [
-        "-i",
-        "--watch"
-      ],
-      "internalConsoleOptions": "openOnSessionStart",
-      "console": "integratedTerminal",
-      "outFiles": [
-        "${workspaceRoot}/build/dist/**/*"
-      ]
     }
   ]
 }

--- a/data/slds/1.1/point_externalgraphic_svg_displacement.sld
+++ b/data/slds/1.1/point_externalgraphic_svg_displacement.sld
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>External Graphic</se:Name>
+    <UserStyle>
+      <se:Name>External Graphic</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name/>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">
+            <se:Graphic>
+              <se:ExternalGraphic>
+                <se:OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg"/>
+                <se:Format>image/svg+xml</se:Format>
+              </se:ExternalGraphic>
+              <se:Size>10</se:Size>
+              <se:Rotation>90</se:Rotation>
+              <se:Displacement>
+                <se:DisplacementX>10</se:DisplacementX>
+                <se:DisplacementY>0</se:DisplacementY>
+              </se:Displacement>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/slds/1.1/point_simplepoint_displacement.sld
+++ b/data/slds/1.1/point_simplepoint_displacement.sld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<StyledLayerDescriptor version="1.1.0"
+  xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:se="http://www.opengis.net/se"
+>
+  <NamedLayer>
+    <se:Name>Simple Point</se:Name>
+    <UserStyle>
+      <se:Name>Simple Point</se:Name>
+      <se:Title>Simple Point</se:Title>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name />
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+                  <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+                  <se:SvgParameter name="stroke-opacity">0.7</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>6</se:Size>
+              <se:Displacement>
+                <se:DisplacementX>13</se:DisplacementX>
+                <se:DisplacementY>37</se:DisplacementY>
+              </se:Displacement>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_externalgraphic_svg_displacement.ts
+++ b/data/styles/point_externalgraphic_svg_displacement.ts
@@ -1,0 +1,17 @@
+import { Style } from 'geostyler-style';
+
+const pointExternalGraphicDisplacement: Style = {
+  name: 'External Graphic',
+  rules: [{
+    name: '',
+    symbolizers: [{
+      kind: 'Icon',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+      size: 10,
+      rotate: 90,
+      offset: [10, 0]
+    }]
+  }]
+};
+
+export default pointExternalGraphicDisplacement;

--- a/data/styles/point_simplepoint_displacement.ts
+++ b/data/styles/point_simplepoint_displacement.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePointDisplacement: Style = {
+  name: 'Simple Point',
+  rules: [{
+    name: '',
+    symbolizers: [{
+      kind: 'Mark',
+      wellKnownName: 'circle',
+      color: '#FF0000',
+      radius: 3,
+      fillOpacity: 0.5,
+      strokeColor: '#0000FF',
+      strokeOpacity: 0.7,
+      offset: [13, 37]
+    }]
+  }]
+};
+
+export default pointSimplePointDisplacement;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "fast-xml-parser": "^4.2.2",
-        "geostyler-style": "^7.2.0"
+        "geostyler-style": "^7.3.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -4905,12 +4905,19 @@
       }
     },
     "node_modules/geostyler-style": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-7.2.0.tgz",
-      "integrity": "sha512-zPM27HFDblqHHR2G5lrxeH3XaylchxbcP8qGhXDoA1UlJ1GsZcGMUzGNa4E1x1S+SOj2MjmGjnyJohU70kO5ww==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-7.3.1.tgz",
+      "integrity": "sha512-9KOXmtRt0O7lhwWfmRORM5l3j3H1uR52NFHlHv1qTb1hgNGZIPhLUrGCaoceUdNkD9+P/Cjiqsea+X+H8h64zw==",
       "dependencies": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
       }
     },
     "node_modules/get-caller-file": {
@@ -13124,9 +13131,9 @@
       "dev": true
     },
     "geostyler-style": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-7.2.0.tgz",
-      "integrity": "sha512-zPM27HFDblqHHR2G5lrxeH3XaylchxbcP8qGhXDoA1UlJ1GsZcGMUzGNa4E1x1S+SOj2MjmGjnyJohU70kO5ww==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-7.3.1.tgz",
+      "integrity": "sha512-9KOXmtRt0O7lhwWfmRORM5l3j3H1uR52NFHlHv1qTb1hgNGZIPhLUrGCaoceUdNkD9+P/Cjiqsea+X+H8h64zw==",
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^4.2.2",
-    "geostyler-style": "^7.2.0"
+    "geostyler-style": "^7.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/src/SldStyleParser.v1.1.spec.ts
+++ b/src/SldStyleParser.v1.1.spec.ts
@@ -20,12 +20,14 @@ import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simpleLabel from '../data/styles/point_simpleLabel';
 import point_simpleLabel2 from '../data/styles/point_simpleLabel2';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
+import point_simplepoint_displacement from '../data/styles/point_simplepoint_displacement';
 import point_simplepoint_filter_forceBools from '../data/styles/point_simplepoint_filter_forceBools';
 import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplepoint_filter_forceNumerics';
 import point_simplepoint_nestedLogicalFilters from '../data/styles/point_simplepoint_nestedLogicalFilters';
 import point_externalgraphic from '../data/styles/point_externalgraphic';
 import point_externalgraphic_floatingPoint from '../data/styles/point_externalgraphic_floatingPoint';
 import point_externalgraphic_svg from '../data/styles/point_externalgraphic_svg';
+import point_externalgraphic_svg_displacement from '../data/styles/point_externalgraphic_svg_displacement';
 import multi_simplelineLabel from '../data/styles/multi_simplelineLabel';
 import point_simplesquare from '../data/styles/point_simplesquare';
 import point_simpletriangle from '../data/styles/point_simpletriangle';
@@ -67,6 +69,12 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser', () => 
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint);
     });
+    it('can read a SLD 1.1 PointSymbolizer with Displacment', async () => {
+      const sld = fs.readFileSync('./data/slds/1.1/point_simplepoint_displacement.sld', 'utf8');
+      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplepoint_displacement);
+    });
     it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic.sld', 'utf8');
       const { output: geoStylerStyle} = await styleParser.readStyle(sld);
@@ -84,6 +92,12 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser', () => 
       const { output: geoStylerStyle} = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_externalgraphic_svg);
+    });
+    it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic and Displacement', async () => {
+      const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic_svg_displacement.sld', 'utf8');
+      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_externalgraphic_svg_displacement);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName square', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplesquare.sld', 'utf8');
@@ -355,6 +369,14 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser', () => 
       const { output: readStyle} = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint);
     });
+    it('can write a SLD 1.1 PointSymbolizer with Displacement', async () => {
+      const { output: sldString } = await styleParser.writeStyle(point_simplepoint_displacement);
+      expect(sldString).toBeDefined();
+      // As string comparison between two XML-Strings is awkward and nonsens
+      // we read it again and compare the json input with the parser output
+      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      expect(readStyle).toEqual(point_simplepoint_displacement);
+    });
     it('can write a SLD 1.1 PointSymbolizer with ExternalGraphic', async () => {
       const { output: sldString } = await styleParser.writeStyle(point_externalgraphic);
       expect(sldString).toBeDefined();
@@ -370,6 +392,14 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser', () => 
       // we read it again and compare the json input with the parser output
       const { output: readStyle} = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_externalgraphic_svg);
+    });
+    it('can write a SLD 1.1 PointSymbolizer with ExternalGraphic svg and displacment', async () => {
+      const { output: sldString } = await styleParser.writeStyle(point_externalgraphic_svg_displacement);
+      expect(sldString).toBeDefined();
+      // As string comparison between two XML-Strings is awkward and nonsens
+      // we read it again and compare the json input with the parser output
+      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      expect(readStyle).toEqual(point_externalgraphic_svg_displacement);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName square', async () => {
       const { output: sldString } = await styleParser.writeStyle(point_simplesquare);


### PR DESCRIPTION
This adds support for reading and writing `Displacement` of the `Graphic` element.

The support is limited to SLD Version 1.1.0.