### PR TITLE
fix: remove unnecessary ogc: prefix from filter

### DIFF
--- a/data/slds/1.0/function_filter.sld
+++ b/data/slds/1.0/function_filter.sld
@@ -8,7 +8,7 @@
       <FeatureTypeStyle>
         <Rule>
           <Name>Function Property Rule 0</Name>
-          <Filter>
+          <Filter xmlns="http://www.opengis.net/ogc">
             <Function name="equalTo">
               <Function name="between">
                 <PropertyName>testprop</PropertyName>

--- a/data/slds/1.1/point_simplepoint_filter.sld
+++ b/data/slds/1.1/point_simplepoint_filter.sld
@@ -7,7 +7,7 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Small populated New Yorks</se:Name>
-          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+          <Filter xmlns="http://www.opengis.net/ogc">
             <And>
               <PropertyIsEqualTo>
                 <PropertyName>NAME</PropertyName>
@@ -54,7 +54,7 @@
                 </UpperBoundary>
               </PropertyIsBetween>
             </And>
-          </ogc:Filter>
+          </Filter>
           <se:MinScaleDenominator>10000</se:MinScaleDenominator>
           <se:MaxScaleDenominator>20000</se:MaxScaleDenominator>
           <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">

--- a/data/slds/1.1/point_simplepoint_functionfilter.sld
+++ b/data/slds/1.1/point_simplepoint_functionfilter.sld
@@ -7,7 +7,7 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Small populated New Yorks</se:Name>
-          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+          <Filter xmlns="http://www.opengis.net/ogc">
             <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
               <Function name="strMatches">
                 <PropertyName>year</PropertyName>
@@ -15,7 +15,7 @@
               </Function>
               <Literal>true</Literal>
             </PropertyIsLike>
-          </ogc:Filter>
+          </Filter>
           <se:MinScaleDenominator>10000</se:MinScaleDenominator>
           <se:MaxScaleDenominator>20000</se:MaxScaleDenominator>
           <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">

--- a/data/slds/1.1/point_simplepoint_nestedLogicalFilters.sld
+++ b/data/slds/1.1/point_simplepoint_nestedLogicalFilters.sld
@@ -7,7 +7,7 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Test</se:Name>
-          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+          <Filter xmlns="http://www.opengis.net/ogc">
             <And>
               <Or>
                 <PropertyIsEqualTo>
@@ -40,7 +40,7 @@
                 </And>
               </Or>
             </And>
-          </ogc:Filter>
+          </Filter>
           <se:MinScaleDenominator>10000</se:MinScaleDenominator>
           <se:MaxScaleDenominator>20000</se:MaxScaleDenominator>
           <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1174,10 +1174,6 @@ export class SldStyleParser implements StyleParser<string> {
    * @returns The tagName as used by the configured sldVersion
    */
   getTagName(tagName: string): string {
-    const ogcList = ['Filter'];
-    if (ogcList.includes(tagName)) {
-      return this.sldVersion === '1.1.0' ? `ogc:${tagName}` : tagName;
-    }
     if (tagName === 'CssParameter') {
       return this.sldVersion === '1.1.0' ? 'se:SvgParameter' : 'CssParameter';
     }


### PR DESCRIPTION
The `ogc:` prefix for filters should be obsolete, since we are also setting the default namespace to ogc. This is the same for both supported SLD versions