### PR TITLE
Fix reading CDATA values from SLD

### DIFF
--- a/data/slds/1.0/cdata.sld
+++ b/data/slds/1.0/cdata.sld
@@ -1,6 +1,9 @@
 <!--SLD file created with GeoCat Bridge v2.0.0 using ArcGIS Desktop with
 	Geoserver extensions. Date: 18 February 2016 See www.geocat.net for more
-	details -->
+	details
+	Origin:	https://register.geostandaarden.nl/visualisatie/top10nl/1.2.0/Wegdeel_Vlak_style.sld
+	Date: 09.07.2024
+	-->
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
 	xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/data/slds/1.0/cdata.sld
+++ b/data/slds/1.0/cdata.sld
@@ -1,0 +1,310 @@
+<!--SLD file created with GeoCat Bridge v2.0.0 using ArcGIS Desktop with
+	Geoserver extensions. Date: 18 February 2016 See www.geocat.net for more
+	details -->
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+	xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
+	version="1.0.0">
+	<NamedLayer>
+		<Name>Wegdeel_vlak</Name>
+		<UserStyle>
+			<Name>Wegdeel_vlak_style</Name>
+			<Title>Wegdeel vlak style</Title>
+			<FeatureTypeStyle>
+				<Rule>
+					<Name>autosnelweg</Name>
+					<Title>autosnelweg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10202]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10200]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10201]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#996089</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>fietspad</Name>
+					<Title>fietspad</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10742]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10740]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10741]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFD37F</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>half verharde weg</Name>
+					<Title>half verharde weg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10721]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10720]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#B3B300</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>hoofdweg</Name>
+					<Title>hoofdweg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10302]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10300]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10401]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10310]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10311]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10312]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#E60000</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>lokale weg</Name>
+					<Title>lokale weg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10502]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10500]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10501]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10510]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10511]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10512]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFFF00</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>onverharde weg</Name>
+					<Title>onverharde weg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10732]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10730]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10731]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#9C9C9C</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>overige weg</Name>
+					<Title>overige weg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10790]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10700]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10701]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10702]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10710]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10711]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10712]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10791]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10792]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFFFFF</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>parkeerplaats</Name>
+					<Title>parkeerplaats</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10781]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10780]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFFFFF</CssParameter>
+						</Fill>
+						<Stroke>
+							<CssParameter name="stroke">#343434</CssParameter>
+							<CssParameter name="stroke-width">1</CssParameter>
+						</Stroke>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>regionale weg</Name>
+					<Title>regionale weg</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10402]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10400]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10301]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10410]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10411]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10412]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFAA00</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>rolbaan, platform</Name>
+					<Title>rolbaan, platform</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10102]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10100]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10101]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#CCCCCC</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>startbaan, landingsbaan</Name>
+					<Title>startbaan, landingsbaan</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10002]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10000]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#CCCCCC</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>straat</Name>
+					<Title>straat</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10602]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10601]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10600]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFFFFF</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+				<Rule>
+					<Name>voetgangersgebied</Name>
+					<Title>voetgangersgebied</Title>
+					<ogc:Filter>
+						<ogc:PropertyIsEqualTo>
+							<ogc:Function name="in">
+								<ogc:PropertyName>visualisatiecode</ogc:PropertyName>
+								<ogc:Literal><![CDATA[10760]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10750]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10751]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10752]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10761]]></ogc:Literal>
+								<ogc:Literal><![CDATA[10762]]></ogc:Literal>
+							</ogc:Function>
+							<ogc:Literal>true</ogc:Literal>
+						</ogc:PropertyIsEqualTo>
+					</ogc:Filter>
+					<MaxScaleDenominator>40000</MaxScaleDenominator>
+					<PolygonSymbolizer>
+						<Fill>
+							<CssParameter name="fill">#FFA77F</CssParameter>
+						</Fill>
+					</PolygonSymbolizer>
+				</Rule>
+			</FeatureTypeStyle>
+		</UserStyle>
+	</NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/cdata.ts
+++ b/data/styles/cdata.ts
@@ -1,0 +1,416 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  name: 'Wegdeel_vlak_style',
+  rules: [
+    {
+      name: 'autosnelweg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10202,
+            10200,
+            10201
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#996089'
+        }
+      ]
+    },
+    {
+      name: 'fietspad',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10742,
+            10740,
+            10741
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFD37F'
+        }
+      ]
+    },
+    {
+      name: 'half verharde weg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10721,
+            10720
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#B3B300'
+        }
+      ]
+    },
+    {
+      name: 'hoofdweg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10302,
+            10300,
+            10401,
+            10310,
+            10311,
+            10312
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#E60000'
+        }
+      ]
+    },
+    {
+      name: 'lokale weg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10502,
+            10500,
+            10501,
+            10510,
+            10511,
+            10512
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFFF00'
+        }
+      ]
+    },
+    {
+      name: 'onverharde weg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10732,
+            10730,
+            10731
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#9C9C9C'
+        }
+      ]
+    },
+    {
+      name: 'overige weg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10790,
+            10700,
+            10701,
+            10702,
+            10710,
+            10711,
+            10712,
+            10791,
+            10792
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFFFFF'
+        }
+      ]
+    },
+    {
+      name: 'parkeerplaats',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10781,
+            10780
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFFFFF',
+          outlineColor: '#343434',
+          outlineWidth: 1
+        }
+      ]
+    },
+    {
+      name: 'regionale weg',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10402,
+            10400,
+            10301,
+            10410,
+            10411,
+            10412
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFAA00'
+        }
+      ]
+    },
+    {
+      name: 'rolbaan, platform',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10102,
+            10100,
+            10101
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#CCCCCC'
+        }
+      ]
+    },
+    {
+      name: 'startbaan, landingsbaan',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10002,
+            10000
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#CCCCCC'
+        }
+      ]
+    },
+    {
+      name: 'straat',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10602,
+            10601,
+            10600
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFFFFF'
+        }
+      ]
+    },
+    {
+      name: 'voetgangersgebied',
+      filter: [
+        '==',
+        {
+          name: 'in',
+          args: [
+            {
+              name: 'property',
+              args: [
+                'visualisatiecode'
+              ]
+            },
+            10760,
+            10750,
+            10751,
+            10752,
+            10761,
+            10762
+          ]
+        },
+        true
+      ],
+      scaleDenominator: {
+        max: 40000
+      },
+      symbolizers: [
+        {
+          kind: 'Fill',
+          color: '#FFA77F'
+        }
+      ]
+    }
+  ]
+};
+
+export default lineSimpleLine;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "fast-xml-parser": "^4.2.2",
-        "geostyler-style": "^9.0.1",
+        "geostyler-style": "^9.1.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -4522,9 +4522,9 @@
       }
     },
     "node_modules/geostyler-style": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-9.0.1.tgz",
-      "integrity": "sha512-gQ5hQPS1NTBXyVAI1GDeg6nLgV1tl1vYarYk/YJczcAHoNy3/kYVY0TTdNxF52NTuRoN2l77KMgQy+JDLu69Dg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-9.1.0.tgz",
+      "integrity": "sha512-kExQDe2mf4YaVMZPKE7h2uxU5qSyAQoX2U2hLXyAWubJjeNoFe0nxt6rKn7C9Q1DE/9DVZopOdNLCXMtqOE6QA==",
       "engines": {
         "node": ">=20.6.0",
         "npm": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^4.2.2",
-    "geostyler-style": "^9.0.1",
+    "geostyler-style": "^9.1.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/src/SldParser.spec.ts
+++ b/src/SldParser.spec.ts
@@ -6,11 +6,12 @@ import SldStyleParser from './SldStyleParser';
 import { expect, it, describe } from 'vitest';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
+import cdata from '../data/styles/cdata';
 
 describe('SldStyleParser implements StyleParser (reading from one version and writing to another version)', () => {
   it('can read and write a SLD PointSymbolizer (from 1.0.0 version to 1.1.0 version)', async () => {
     const styleParser = new SldStyleParser({sldVersion: '1.1.0'});
-    
+
     const sld = fs.readFileSync('./data/slds/1.0/point_simplepoint.sld', 'utf8');
     const { output: geoStylerStyle } = await styleParser.readStyle(sld);
     expect(geoStylerStyle).toBeDefined();
@@ -23,7 +24,7 @@ describe('SldStyleParser implements StyleParser (reading from one version and wr
     } = await styleParser.writeStyle(geoStylerStyle!);
     expect(sldString).toBeDefined();
     expect(errors).toBeUndefined();
-    
+
     // As string comparison between two XML-Strings is awkward and nonsens
     // we read it again and compare the json input with the parser output
     const { output: readStyle } = await styleParser.readStyle(sldString!);
@@ -44,11 +45,21 @@ describe('SldStyleParser implements StyleParser (reading from one version and wr
     } = await styleParser.writeStyle(geoStylerStyle!);
     expect(sldString).toBeDefined();
     expect(errors).toBeUndefined();
-    
+
     // As string comparison between two XML-Strings is awkward and nonsens
     // we read it again and compare the json input with the parser output
     const { output: readStyle } = await styleParser.readStyle(sldString!);
     expect(readStyle).toEqual(point_simplepoint);
   });
-});
 
+  it('can read CDATA values', async () => {
+    const styleParser = new SldStyleParser({
+      sldVersion: '1.0.0'
+    });
+
+    const sld = fs.readFileSync('./data/slds/1.0/cdata.sld', 'utf8');
+    const { output: geoStylerStyle } = await styleParser.readStyle(sld);
+    expect(geoStylerStyle).toBeDefined();
+    expect(geoStylerStyle).toEqual(cdata);
+  });
+});

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -117,7 +117,7 @@ export const defaultTranslations: SldStyleParserTranslations = {
     marksymbolizerParseFailedUnknownWellknownName: ({wellKnownName}) =>
       `MarkSymbolizer cannot be parsed. WellKnownName ${wellKnownName} is not supported.`,
     noFilterDetected: 'No Filter detected.',
-    symbolizerKindParseFailed: ({sldSymbolizerName}) => 
+    symbolizerKindParseFailed: ({sldSymbolizerName}) =>
       `Failed to parse SymbolizerKind ${sldSymbolizerName} from SldRule.`,
     colorMapEntriesParseFailedColorUndefined: 'Cannot parse ColorMapEntries. color is undefined.',
     contrastEnhancParseFailedHistoAndNormalizeMutuallyExclusive:
@@ -132,7 +132,7 @@ export const defaultTranslations: SldStyleParserTranslations = {
     marksymbolizerParseFailedUnknownWellknownName: ({wellKnownName}) =>
       `Échec de lecture du symbole de type MarkSymbolizer. Le WellKnownName ${wellKnownName} n'est pas supporté.`,
     noFilterDetected: 'Aucun filtre détecté.',
-    symbolizerKindParseFailed: ({sldSymbolizerName}) => 
+    symbolizerKindParseFailed: ({sldSymbolizerName}) =>
       `Échec de lecture du type de symbole ${sldSymbolizerName} à partir de SldRule.`,
     colorMapEntriesParseFailedColorUndefined: 'Lecture de ColorMapEntries échoué. color n\'est pas défini.',
     contrastEnhancParseFailedHistoAndNormalizeMutuallyExclusive:
@@ -250,7 +250,6 @@ export class SldStyleParser implements StyleParser<string> {
     this.parser = new XMLParser({
       ...opts?.parserOptions,
       // Fixed attributes
-      cdataPropName: '#cdata',
       ignoreDeclaration: true,
       removeNSPrefix: true,
       ignoreAttributes: false,


### PR DESCRIPTION
This fixes parsing of `<![CDATA[xxx]]>` values.

It removes the configured `cdataPropName` from the parser.

Closes #947 

@louwers i used your linked SLD for this test. If you don't want it to be in the repo just let me know and i will break it down to a simpler example and use this instead.